### PR TITLE
[#11] Update to GO 1.16.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE settings
+.vscode
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.3
+FROM golang:1.16.2
 
 ENV GO111MODULE=on
 WORKDIR /app/

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lint-local:
 	${LINTER} run ./...
 
 .PHONY: lint
-lint:
+lint: .docker
 	${DOCKER_RUNTIME_CMD} lint-local
 
 .PHONY: build-local

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module golang-repository-template
 
-go 1.15
+go 1.16


### PR DESCRIPTION
This will close #11 

# Changes
- Update to 1.16
- Fix Makefile's linter bug
- Ignore .vscode folder